### PR TITLE
Add licensing terms and attributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Artwork for the extendr project
 
+## Licensing terms for logos
+
+The extendr logo and hexlogo are distributed under the terms of the [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/) (CC-BY-SA 4.0).
+
+## Attribution
+
+* [The R logo](https://www.r-project.org/logo/) by The R Foundation is licensed under [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+* [The Rust logo](https://github.com/rust-lang/rust-artwork) by Mozilla is licensed munder [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
This PR adds a brief explanation about the licenses. While https://github.com/extendr/extendr/issues/108#issuecomment-753791883 suggested to use `LICENSE`, I feel `README` is better as this repo might contain other artworks that are licensed differently in future.

For attribution, I followed this wiki on Creative Commons' wiki, but I'm not sure if this appropriate in our context. Please propose a better format if you come up with something nice :)

https://wiki.creativecommons.org/wiki/Best_practices_for_attribution